### PR TITLE
Add CodeBuild badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Git Actions 2 Elastic Container Registry
 This is a test repo using [bottlerocket-os/bottlerocket-admin-container](https://github.com/bottlerocket-os/bottlerocket-admin-container) as a base for the initial commit.
+
+![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoia0pqZENsczNMZ2g1RUFoNVpsaktQMzJaVHBheUlHSXJweWhvUW15ZG8zZjF5RXNENHdMTUZYdVVKbS84OWhDVWN4VWpTamtNcUI0L05rZGRXY0h2a2s0PSIsIml2UGFyYW1ldGVyU3BlYyI6IlE4bEJOMFFCOVpvM2hiUG4iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)


### PR DESCRIPTION
It would be nice if we had a fancy CodeBuild badge to show the status of the last build from merge.